### PR TITLE
[Examples] Add original sky_train example, distributed data processing workflow, and update YAML file urls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
 ARG AIRFLOW_VERSION=3.0.0
 FROM apache/airflow:${AIRFLOW_VERSION}
 
-
 # Install our provider
 USER root
 RUN apt-get update && apt-get install -y git && apt-get clean
 USER airflow
 # TODO: Install from PyPI once released
-RUN pip install git+https://github.com/skypilot-org/airflow-provider-skypilot.git@master
+RUN pip install git+https://github.com/skypilot-org/airflow-provider-skypilot.git@v0.1.0
 # Or if building locally:
 # COPY --chown=airflow:root . /opt/airflow/providers/airflow-provider-skypilot/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+ARG AIRFLOW_VERSION=3.0.0
+FROM apache/airflow:${AIRFLOW_VERSION}
+
+
+# Install our provider
+USER root
+RUN apt-get update && apt-get install -y git && apt-get clean
+USER airflow
+# TODO: Install from PyPI once released
+RUN pip install git+https://github.com/skypilot-org/airflow-provider-skypilot.git@master
+# Or if building locally:
+# COPY --chown=airflow:root . /opt/airflow/providers/airflow-provider-skypilot/
+
+# Copy example DAGs to Airflow's DAGs directory
+COPY --chown=airflow:root example_dags/ /opt/airflow/dags/

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ More operators like `SkyJobOperator` are in the roadmap, so stay tuned for that 
 
 ## Installation
 
-You can install this package on top of an existing Airflow deployment via `pip install airflow-provider-skypilot`. For the minimum Airflow version supported, see [Requirements](#requirements) below.
+You can install this package on top of an existing Airflow deployment via `pip install git+https://github.com/skypilot-org/airflow-provider-skypilot.git@v0.1.0`. For the minimum Airflow version supported, see [Requirements](#requirements) below.
 
 You should be able to see `airflow-provider-skypilot` on the Providers page
 upon successful installation.
@@ -86,7 +86,7 @@ upon successful installation.
     sky_training_workflow()
     ```
 
-See `example_dags/` for more examples.
+See [example_dags/](example_dags/README.md) for more examples and instructions on how to run them.
 
 ## Managing SkyPilot Version
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,13 @@ upon successful installation.
     sky_training_workflow()
     ```
 
-See [example_dags/](example_dags/README.md) for more examples and instructions on how to run them.
+## Examples
+
+We put up some additional examples in [examples_dags/](example_dags/), including:
+
+1. Parallel data processing pipeline: [NYC taxi data processing](example_dags/README.md#example-1-nyc-taxi-data-processing-pipeline)
+2. Data preprocessing -> Training -> Eval pipeline: [Machine learning training](example_dags/README.md#example-2-machine-learning-training-pipeline)
+3. Cloud credentials integration: [AWS credentials integration](example_dags/README.md#example-5-aws-credentials-integration), [GCP credentials integration](example_dags/README.md#example-6-gcp-credentials-integration)
 
 ## Managing SkyPilot Version
 

--- a/example_dags/README.md
+++ b/example_dags/README.md
@@ -3,11 +3,55 @@
 This directory contains several example Airflow DAGs to demonstrate how to use the
 `SkyPilotClusterOperator`.
 
+## Overview
+
+### Example 1: NYC Taxi Data Processing Pipeline
+
+[sky_nyc_taxi_data.py](sky_nyc_taxi_data.py) includes the definition of the DAG. This example demonstrates a large-scale data processing workflow that processes NYC taxi trip data from 2009-2025. It involves the following stages:
+
+1. **Preprocessing Stage**: Generates a unique bucket UUID and creates parallel task configurations for processing multiple years of data in parallel
+2. **Parallel Data Processing Stage**: In parallel, downloads NYC taxi trip data (parquet files) from the NYC TLC website for each year, processes the data using DuckDB to calculate sum and count of total amounts, and stores intermediate results in cloud storage (S3 or GCS)
+3. **Data Aggregation Stage**: Reads all intermediate results from cloud storage and calculates the overall average taxi fare across all years and trips
+
+### Example 2: Machine Learning Training Pipeline
+
+[sky_train.py](sky_train.py) includes the definition of the DAG. This example demonstrates a complete mock ML training workflow. It involves the following stages:
+
+1. **Data Preprocessing Stage**: Prepares and cleans raw data for training using a dedicated preprocessing task
+2. **Model Training Stage**: Trains a machine learning model using the preprocessed data
+3. **Model Evaluation Stage**: Evaluates the trained model's performance and generates metrics
+
+### Example 3: Simple Hello World
+
+[sky_hello.py](sky_hello.py) includes the definition of the DAG. This is the simplest example that demonstrates basic SkyPilot integration. It involves the following stage:
+
+1. **Hello Task**: Executes a simple `echo "Hello, SkyPilot!"` command and displays the conda environment list to verify the cluster setup
+
+### Example 4: Local Hello World
+
+[sky_hello_local.py](sky_hello_local.py) includes the definition of the DAG. This example is similar to the simple hello world but uses local YAML files instead of remote ones. It involves the following stage:
+
+1. **Hello Task**: Executes a simple `echo "Hello, SkyPilot!"` command using a locally mounted YAML file
+
+### Example 5: AWS Credentials Integration
+
+[sky_aws_credentials.py](sky_aws_credentials.py) includes the definition of the DAG. This example demonstrates how to use AWS credentials stored in Airflow connections with SkyPilot tasks. It involves the following stage:
+
+1. **AWS Integration Task**: Sets up AWS CLI, authenticates using provided credentials, and displays the current AWS identity to verify proper credential configuration
+
+### Example 6: GCP Credentials Integration
+
+[sky_gcp_credentials.py](sky_gcp_credentials.py) includes the definition of the DAG. This example demonstrates how to use Google Cloud Platform credentials stored in Airflow connections with SkyPilot tasks. It involves the following stage:
+
+1. **GCP Integration Task**: Sets up Google Cloud SDK, authenticates using provided credentials, and displays the current GCP identity to verify proper credential configuration
+
+## Running the Examples
+
 To run these examples, you need:
 1. A SkyPilot remote API server (see [Configuration and Usage](../README.md#configuration-and-usage))
 2. An Airflow deployment
 3. An extended Airflow image which has `airflow-provider-skypilot` installed (along with other
-additional dependencies you may have)
+additional dependencies you may have). Refer to our [Dockerfile](../Dockerfile) for how to create the extended image.
 
 If you already have an existing Airflow deployment, and have added `airflow-provider-skypilot` to your custom Airflow image, you can jump ahead to [Triggering the DAG](#triggering-the-dag).
 
@@ -63,7 +107,7 @@ to trigger the DAG run:
 1. Go to the DAGs [page](http://localhost:8080/dags?tags=skypilot) and filter with `tags=skypilot`
 
 <p align="center">
-    <img alt="Airflow DAGs page" src="https://i.imgur.com/HvZbPlF.png" width="720">
+    <img alt="Airflow DAGs page" src="https://i.imgur.com/xpdyDre.png" width="720">
 </p>
 
 2. Press the <span>&#9654;</span> (trigger) button on the right

--- a/example_dags/README.md
+++ b/example_dags/README.md
@@ -51,7 +51,9 @@ based on Airflow's official [guide](https://airflow.apache.org/docs/apache-airfl
 
 5. The Airflow API server should now be available at http://localhost:8080. By default, the account created has the username `airflow` and the password `airflow`.
 
-<img alt="Airflow login page" src="https://i.imgur.com/PVIgNBc.png" width="720">
+<p align="center">
+    <img alt="Airflow login page" src="https://i.imgur.com/PVIgNBc.png" width="720">
+</p>
 
 ## Triggering the DAG
 
@@ -60,20 +62,28 @@ to trigger the DAG run:
 
 1. Go to the DAGs [page](http://localhost:8080/dags?tags=skypilot) and filter with `tags=skypilot`
 
-<img alt="Airflow DAGs page" src="https://i.imgur.com/HvZbPlF.png" width="720">
+<p align="center">
+    <img alt="Airflow DAGs page" src="https://i.imgur.com/HvZbPlF.png" width="720">
+</p>
 
 2. Press the <span>&#9654;</span> (trigger) button on the right
 
 3. Some example DAGs which interact with object storage allow you to choose between using S3 or GCS
 
-<img alt="Airflow DAG trigger modal" src="https://i.imgur.com/Fs6IcVl.png" width="720">
+<p align="center">
+    <img alt="Airflow DAG trigger modal" src="https://i.imgur.com/Fs6IcVl.png" width="720">
+</p>
 
 4. Click on "Trigger"
 
 5. Click on the DAG name to go to the detailed page, for example http://localhost:8080/dags/sky_nyc_taxi_data
 
-<img alt="Airflow DAG detail page" src="https://i.imgur.com/uhbwy2S.png" width="720">
-<img alt="Airflow DAG run page" src="https://i.imgur.com/KzEQflK.png" width="720">
+<p align="center">
+    <img alt="Airflow DAG detail page" src="https://i.imgur.com/uhbwy2S.png" width="720">
+</p>
+<p align="center">
+    <img alt="Airflow DAG run page" src="https://i.imgur.com/KzEQflK.png" width="720">
+</p>
 
 ## (Optional) Cleaning up the Docker Compose environment
 

--- a/example_dags/README.md
+++ b/example_dags/README.md
@@ -1,0 +1,83 @@
+# Running Example DAGs
+
+This directory contains several example Airflow DAGs to demonstrate how to use the
+`SkyPilotClusterOperator`.
+
+To run these examples, you need:
+1. A SkyPilot remote API server (see [Configuration and Usage](../README.md#configuration-and-usage))
+2. An Airflow deployment
+3. An extended Airflow image which has `airflow-provider-skypilot` installed (along with other
+additional dependencies you may have)
+
+If you already have an existing Airflow deployment, and have added `airflow-provider-skypilot` to your custom Airflow image, you can jump ahead to [Triggering the DAG](#triggering-the-dag).
+
+## (Optional) Setting up Airflow locally using a custom image
+
+The simplest way to run Airflow locally is by using [Docker](https://docs.docker.com/get-started/) and
+[Docker Compose](https://docs.docker.com/get-started/workshop/08_using_compose/). These are the steps
+based on Airflow's official [guide](https://airflow.apache.org/docs/apache-airflow/stable/howto/docker-compose/index.html).
+
+1. Clone this repository:
+    ```bash
+    git clone git@github.com:skypilot-org/airflow-provider-skypilot.git
+    cd airflow-provider-skypilot
+    ```
+2. Fetch `docker-compose.yaml`:
+    ```bash
+    curl -LfO 'https://airflow.apache.org/docs/apache-airflow/3.0.0/docker-compose.yaml'
+    ```
+3. Modify `docker-compose.yaml` to use our custom [Dockerfile](../Dockerfile) which has
+`airflow-provider-skypilot` installed:
+
+    Comment out the `image: ...` line and remove comment from the `build: .` line in the `docker-compose.yaml` file. The relevant part of the docker-compose file of yours should look similar to:
+    ```yaml
+    x-airflow-common:
+        &airflow-common
+        # In order to add custom dependencies or upgrade provider distributions you can use your extended image.
+        # Comment the image line, place your Dockerfile in the directory where you placed the docker-compose.yaml
+        # and uncomment the "build" line below, Then run `docker-compose build` to build the images.
+        # image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:3.0.0}
+        build: .
+    ```
+4. Run the Docker Compose
+    ```bash
+    # Build the custom image
+    docker compose build
+    # One-time DB initialization
+    docker compose up airflow-init
+    # Start all services
+    docker compose up
+    ```
+
+5. The Airflow API server should now be available at http://localhost:8080. By default, the account created has the username `airflow` and the password `airflow`.
+
+<img alt="Airflow login page" src="https://i.imgur.com/PVIgNBc.png" width="720">
+
+## Triggering the DAG
+
+Once you have Airflow running and `airflow-provider-skypilot` installed, you can do the following
+to trigger the DAG run:
+
+1. Go to the DAGs [page](http://localhost:8080/dags?tags=skypilot) and filter with `tags=skypilot`
+
+<img alt="Airflow DAGs page" src="https://i.imgur.com/HvZbPlF.png" width="720">
+
+2. Press the <span>&#9654;</span> (trigger) button on the right
+
+3. Some example DAGs which interact with object storage allow you to choose between using S3 or GCS
+
+<img alt="Airflow DAG trigger modal" src="https://i.imgur.com/Fs6IcVl.png" width="720">
+
+4. Click on "Trigger"
+
+5. Click on the DAG name to go to the detailed page, for example http://localhost:8080/dags/sky_nyc_taxi_data
+
+<img alt="Airflow DAG detail page" src="https://i.imgur.com/uhbwy2S.png" width="720">
+<img alt="Airflow DAG run page" src="https://i.imgur.com/KzEQflK.png" width="720">
+
+## (Optional) Cleaning up the Docker Compose environment
+
+Run `docker compose down --volumes --remove-orphans` from the same directory as before.
+
+## References
+- https://airflow.apache.org/docs/apache-airflow/stable/howto/docker-compose/index.html

--- a/example_dags/README.md
+++ b/example_dags/README.md
@@ -7,7 +7,7 @@ This directory contains several example Airflow DAGs to demonstrate how to use t
 * [Overview](#overview)
   + [Example 1: NYC Taxi Data Processing Pipeline](#example-1-nyc-taxi-data-processing-pipeline)
   + [Example 2: Machine Learning Training Pipeline](#example-2-machine-learning-training-pipeline)
-  + [Example 3: Simple Hello World](#example-3-simple-hello-world)
+  + [Example 3: Hello World](#example-3-hello-world)
   + [Example 4: Local Hello World](#example-4-local-hello-world)
   + [Example 5: AWS Credentials Integration](#example-5-aws-credentials-integration)
   + [Example 6: GCP Credentials Integration](#example-6-gcp-credentials-integration)
@@ -35,7 +35,7 @@ This directory contains several example Airflow DAGs to demonstrate how to use t
 2. **Model Training Stage**: Trains a machine learning model using the preprocessed data
 3. **Model Evaluation Stage**: Evaluates the trained model's performance and generates metrics
 
-### Example 3: Simple Hello World
+### Example 3: Hello World
 
 [sky_hello.py](sky_hello.py) includes the definition of the DAG. This is the simplest example that demonstrates basic SkyPilot integration. It involves the following stage:
 

--- a/example_dags/README.md
+++ b/example_dags/README.md
@@ -12,9 +12,9 @@ This directory contains several example Airflow DAGs to demonstrate how to use t
   + [Example 5: AWS Credentials Integration](#example-5-aws-credentials-integration)
   + [Example 6: GCP Credentials Integration](#example-6-gcp-credentials-integration)
 * [Running the Examples](#running-the-examples)
-* [(Optional) Setting up Airflow locally using a custom image](#-optional--setting-up-airflow-locally-using-a-custom-image)
+* [(Optional) Setting up Airflow locally using a custom image](#optional-setting-up-airflow-locally-using-a-custom-image)
 * [Triggering the DAG](#triggering-the-dag)
-* [(Optional) Cleaning up the Docker Compose environment](#-optional--cleaning-up-the-docker-compose-environment)
+* [(Optional) Cleaning up the Docker Compose environment](#optional-cleaning-up-the-docker-compose-environment)
 * [References](#references)
 
 ## Overview

--- a/example_dags/README.md
+++ b/example_dags/README.md
@@ -3,6 +3,20 @@
 This directory contains several example Airflow DAGs to demonstrate how to use the
 `SkyPilotClusterOperator`.
 
+## Table of Contents
+* [Overview](#overview)
+  + [Example 1: NYC Taxi Data Processing Pipeline](#example-1-nyc-taxi-data-processing-pipeline)
+  + [Example 2: Machine Learning Training Pipeline](#example-2-machine-learning-training-pipeline)
+  + [Example 3: Simple Hello World](#example-3-simple-hello-world)
+  + [Example 4: Local Hello World](#example-4-local-hello-world)
+  + [Example 5: AWS Credentials Integration](#example-5-aws-credentials-integration)
+  + [Example 6: GCP Credentials Integration](#example-6-gcp-credentials-integration)
+* [Running the Examples](#running-the-examples)
+* [(Optional) Setting up Airflow locally using a custom image](#-optional--setting-up-airflow-locally-using-a-custom-image)
+* [Triggering the DAG](#triggering-the-dag)
+* [(Optional) Cleaning up the Docker Compose environment](#-optional--cleaning-up-the-docker-compose-environment)
+* [References](#references)
+
 ## Overview
 
 ### Example 1: NYC Taxi Data Processing Pipeline

--- a/example_dags/sky_aws_credentials.py
+++ b/example_dags/sky_aws_credentials.py
@@ -18,7 +18,7 @@ def sky_aws_credentials():
     aws_task = operators.SkyPilotClusterOperator(
         task_id="aws_task",
         yaml_file=
-        "https://raw.githubusercontent.com/skypilot-org/airflow-provider-skypilot/init/example_skypilot_yamls/aws.sky.yaml",
+        "https://raw.githubusercontent.com/skypilot-org/airflow-provider-skypilot/refs/heads/master/example_skypilot_yamls/aws.sky.yaml",
         credentials_override={"aws": "skypilot_aws_task"})
 
     aws_task

--- a/example_dags/sky_gcp_credentials.py
+++ b/example_dags/sky_gcp_credentials.py
@@ -18,7 +18,7 @@ def sky_gcp_credentials():
     gcp_task = operators.SkyPilotClusterOperator(
         task_id="gcp_task",
         yaml_file=
-        "https://raw.githubusercontent.com/skypilot-org/airflow-provider-skypilot/init/example_skypilot_yamls/gcp.sky.yaml",
+        "https://raw.githubusercontent.com/skypilot-org/airflow-provider-skypilot/refs/heads/master/example_skypilot_yamls/gcp.sky.yaml",
         credentials_override={"gcp": "skypilot_gcp_task"})
 
     gcp_task

--- a/example_dags/sky_hello.py
+++ b/example_dags/sky_hello.py
@@ -19,7 +19,7 @@ def sky_hello():
         task_id="hello_task",
         name="mycluster",
         yaml_file=
-        "https://raw.githubusercontent.com/skypilot-org/airflow-provider-skypilot/init/example_skypilot_yamls/hello.sky.yaml",
+        "https://raw.githubusercontent.com/skypilot-org/airflow-provider-skypilot/refs/heads/master/example_skypilot_yamls/hello.sky.yaml",
     )
 
     hello_task

--- a/example_dags/sky_nyc_taxi_data.py
+++ b/example_dags/sky_nyc_taxi_data.py
@@ -1,0 +1,146 @@
+import datetime
+import uuid
+
+from airflow import decorators
+from airflow.models import param
+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from airflow.providers.google.cloud.hooks.gcs import GCSHook
+
+from skypilot_provider import operators
+
+YEARS = [year for year in range(2015, 2026)]
+
+default_args = {
+    "owner": "airflow",
+    "retries": 1,
+}
+
+
+@decorators.task
+def generate_bucket_uuid():
+    """Generate a unique bucket UUID for this DAG run."""
+    return str(uuid.uuid4())[:4]
+
+
+@decorators.task
+def create_parallel_task_configs(bucket_uuid: str):
+    """Create task configurations with the actual bucket UUID."""
+    return [
+        {
+            'envs_override': {
+                'BUCKET_NAME':
+                f'sky-data-demo-{bucket_uuid}',
+                'BUCKET_STORE_TYPE':
+                '{{ dag_run.conf.get("data_bucket_store_type", params.data_bucket_store_type) }}',
+                # Source: https://www.nyc.gov/site/tlc/about/tlc-trip-record-data.page
+                'DATA_URLS':
+                ','.join([
+                    f'https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_{year}-{month}.parquet'
+                    for month in range(1, 13)
+                ]),
+                'YEAR':
+                year,
+            }
+        } for year in YEARS
+    ]
+
+
+@decorators.task
+def calculate_average(bucket_name, storage_type='s3'):
+    """Read all temporary files from cloud storage (S3 or GCS) and calculate the overall average."""
+    if storage_type.lower() == 's3':
+        s3_hook = S3Hook(aws_conn_id='skypilot_aws_task')
+        file_keys = s3_hook.list_keys(bucket_name=bucket_name, prefix='tmp_')
+        if not file_keys:
+            raise ValueError(
+                f"No result files found in S3 bucket {bucket_name}")
+        for file_key in file_keys:
+            print(f"Processing file: {file_key}")
+            content = s3_hook.read_key(key=file_key, bucket_name=bucket_name)
+            total_sum, total_count = _process_file_content(content, file_key)
+
+    elif storage_type.lower() == 'gcs':
+        gcs_hook = GCSHook(gcp_conn_id='skypilot_gcp_task')
+        file_keys = gcs_hook.list(bucket_name=bucket_name, prefix='tmp_')
+        if not file_keys:
+            raise ValueError(
+                f"No result files found in GCS bucket {bucket_name}")
+        for file_key in file_keys:
+            print(f"Processing file: {file_key}")
+            content = gcs_hook.download(bucket_name=bucket_name,
+                                        object_name=file_key)
+            total_sum, total_count = _process_file_content(
+                content.decode('utf-8'), file_key)
+    else:
+        raise ValueError(
+            f"Unsupported storage type: {storage_type}. Supported types are 's3' and 'gcs'"
+        )
+
+    overall_average = total_sum / total_count
+
+    print(f"=== FINAL RESULTS ===")
+    print(f"Total sum: ${total_sum:,.3f}")
+    print(f"Total count: {total_count:,}")
+    print(f"Overall average: ${overall_average:.3f}")
+
+    return {
+        'total_sum': total_sum,
+        'total_count': total_count,
+        'overall_average': overall_average
+    }
+
+
+def _process_file_content(content, file_key):
+    """Helper function to process file content and extract sum/count data."""
+    lines = content.strip().split('\n')
+    if len(lines) < 2:
+        print(f"File {file_key} doesn't have data line, skipping")
+        return 0, 0
+    total_sum = 0
+    total_count = 0
+    try:
+        data_line = lines[1]
+        sum_amount, count_amount = data_line.split(',')
+        total_sum += float(sum_amount)
+        total_count += int(count_amount)
+        print(f"  Sum: {sum_amount}, Count: {count_amount}")
+    except ValueError as e:
+        print(f"Error parsing file {file_key}: {e}")
+    return total_sum, total_count
+
+
+@decorators.dag(
+    default_args=default_args,
+    start_date=datetime.datetime(2025, 1, 1),
+    catchup=False,
+    tags=["skypilot"],
+    params={
+        'data_bucket_store_type':
+        param.Param(
+            's3',
+            enum=['s3', 'gcs'],
+            description='Whether to use S3 or GCS for the data buckets'),
+    })
+def sky_nyc_taxi_data():
+    bucket_uuid = generate_bucket_uuid()
+    task_configs = create_parallel_task_configs(bucket_uuid)
+
+    # Process each year's data in parallel
+    nyc_taxi_data_tasks = operators.SkyPilotClusterOperator.partial(
+        task_id="nyc_taxi_data",
+        yaml_file=
+        "https://raw.githubusercontent.com/skypilot-org/airflow-provider-skypilot/refs/heads/examples/example_skypilot_yamls/nyc_taxi_data.sky.yaml",
+        retry_delay=datetime.timedelta(seconds=10),
+    ).expand_kwargs(task_configs)
+
+    # Calculate overall average after all parallel tasks complete
+    calculate_avg_task = calculate_average(
+        bucket_name=f'sky-data-demo-{bucket_uuid}',
+        storage_type=
+        '{{ dag_run.conf.get("data_bucket_store_type", params.data_bucket_store_type) }}'
+    )
+
+    bucket_uuid >> task_configs >> nyc_taxi_data_tasks >> calculate_avg_task
+
+
+sky_nyc_taxi_data()

--- a/example_dags/sky_nyc_taxi_data.py
+++ b/example_dags/sky_nyc_taxi_data.py
@@ -35,7 +35,7 @@ def create_parallel_task_configs(bucket_uuid: str):
                 # Source: https://www.nyc.gov/site/tlc/about/tlc-trip-record-data.page
                 'DATA_URLS':
                 ','.join([
-                    f'https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_{year}-{month}.parquet'
+                    f'https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_{year}-{month:02d}.parquet'
                     for month in range(1, 13)
                 ]),
                 'YEAR':

--- a/example_dags/sky_nyc_taxi_data.py
+++ b/example_dags/sky_nyc_taxi_data.py
@@ -8,7 +8,7 @@ from airflow.providers.google.cloud.hooks import gcs
 
 from skypilot_provider import operators
 
-YEARS = [year for year in range(2015, 2026)]
+YEARS = [year for year in range(2009, 2026)]
 
 default_args = {
     "owner": "airflow",
@@ -48,6 +48,8 @@ def create_parallel_task_configs(bucket_uuid: str):
 @decorators.task
 def calculate_average(bucket_name, storage_type='s3'):
     """Read all temporary files from cloud storage (S3 or GCS) and calculate the overall average."""
+    total_sum = 0
+    total_count = 0
     if storage_type.lower() == 's3':
         s3_hook = s3.S3Hook(aws_conn_id='skypilot_aws_task')
         file_keys = s3_hook.list_keys(bucket_name=bucket_name, prefix='tmp_')
@@ -57,7 +59,9 @@ def calculate_average(bucket_name, storage_type='s3'):
         for file_key in file_keys:
             print(f"Processing file: {file_key}")
             content = s3_hook.read_key(key=file_key, bucket_name=bucket_name)
-            total_sum, total_count = _process_file_content(content, file_key)
+            file_sum, file_count = _process_file_content(content, file_key)
+            total_sum += file_sum
+            total_count += file_count
 
     elif storage_type.lower() == 'gcs':
         gcs_hook = gcs.GCSHook(gcp_conn_id='skypilot_gcp_task')
@@ -69,8 +73,10 @@ def calculate_average(bucket_name, storage_type='s3'):
             print(f"Processing file: {file_key}")
             content = gcs_hook.download(bucket_name=bucket_name,
                                         object_name=file_key)
-            total_sum, total_count = _process_file_content(
+            file_sum, file_count = _process_file_content(
                 content.decode('utf-8'), file_key)
+            total_sum += file_sum
+            total_count += file_count
     else:
         raise ValueError(
             f"Unsupported storage type: {storage_type}. Supported types are 's3' and 'gcs'"

--- a/example_dags/sky_nyc_taxi_data.py
+++ b/example_dags/sky_nyc_taxi_data.py
@@ -3,8 +3,8 @@ import uuid
 
 from airflow import decorators
 from airflow.models import param
-from airflow.providers.amazon.aws.hooks.s3 import S3Hook
-from airflow.providers.google.cloud.hooks.gcs import GCSHook
+from airflow.providers.amazon.aws.hooks import s3
+from airflow.providers.google.cloud.hooks import gcs
 
 from skypilot_provider import operators
 
@@ -49,7 +49,7 @@ def create_parallel_task_configs(bucket_uuid: str):
 def calculate_average(bucket_name, storage_type='s3'):
     """Read all temporary files from cloud storage (S3 or GCS) and calculate the overall average."""
     if storage_type.lower() == 's3':
-        s3_hook = S3Hook(aws_conn_id='skypilot_aws_task')
+        s3_hook = s3.S3Hook(aws_conn_id='skypilot_aws_task')
         file_keys = s3_hook.list_keys(bucket_name=bucket_name, prefix='tmp_')
         if not file_keys:
             raise ValueError(
@@ -60,7 +60,7 @@ def calculate_average(bucket_name, storage_type='s3'):
             total_sum, total_count = _process_file_content(content, file_key)
 
     elif storage_type.lower() == 'gcs':
-        gcs_hook = GCSHook(gcp_conn_id='skypilot_gcp_task')
+        gcs_hook = gcs.GCSHook(gcp_conn_id='skypilot_gcp_task')
         file_keys = gcs_hook.list(bucket_name=bucket_name, prefix='tmp_')
         if not file_keys:
             raise ValueError(

--- a/example_dags/sky_nyc_taxi_data.py
+++ b/example_dags/sky_nyc_taxi_data.py
@@ -135,7 +135,7 @@ def sky_nyc_taxi_data():
     nyc_taxi_data_tasks = operators.SkyPilotClusterOperator.partial(
         task_id="nyc_taxi_data",
         yaml_file=
-        "https://raw.githubusercontent.com/skypilot-org/airflow-provider-skypilot/refs/heads/examples/example_skypilot_yamls/nyc_taxi_data.sky.yaml",
+        "https://raw.githubusercontent.com/skypilot-org/airflow-provider-skypilot/refs/heads/master/example_skypilot_yamls/nyc_taxi_data.sky.yaml",
         retry_delay=datetime.timedelta(seconds=10),
     ).expand_kwargs(task_configs)
 

--- a/example_dags/sky_train.py
+++ b/example_dags/sky_train.py
@@ -1,0 +1,65 @@
+import datetime
+import uuid
+
+from airflow import decorators
+from airflow.models import param
+
+from skypilot_provider import operators
+
+default_args = {
+    "owner": "airflow",
+    "retries": 1,
+}
+
+
+@decorators.task
+def generate_bucket_uuid():
+    """Generate a unique bucket UUID for this DAG run."""
+    return str(uuid.uuid4())[:4]
+
+
+@decorators.dag(
+    default_args=default_args,
+    start_date=datetime.datetime(2025, 1, 1),
+    catchup=False,
+    tags=["skypilot"],
+    params={
+        'data_bucket_store_type':
+        param.Param(
+            's3',
+            enum=['s3', 'gcs'],
+            description='Whether to use S3 or GCS for the data buckets'),
+    })
+def sky_train():
+    bucket_uuid = generate_bucket_uuid()
+
+    common_envs = {
+        'DATA_BUCKET_NAME':
+        f'sky-data-demo-{bucket_uuid}',
+        'DATA_BUCKET_STORE_TYPE':
+        '{{ dag_run.conf.get("data_bucket_store_type", params.data_bucket_store_type) }}',
+    }
+
+    preprocess_task = operators.SkyPilotClusterOperator(
+        task_id='data_preprocess',
+        yaml_file=
+        'https://raw.githubusercontent.com/skypilot-org/mock-train-workflow/refs/heads/main/data_preprocessing.yaml',
+        envs_override=common_envs,
+    )
+    train_task = operators.SkyPilotClusterOperator(
+        task_id='train',
+        yaml_file=
+        'https://raw.githubusercontent.com/skypilot-org/mock-train-workflow/refs/heads/main/train.yaml',
+        envs_override=common_envs,
+    )
+    eval_task = operators.SkyPilotClusterOperator(
+        task_id='eval',
+        yaml_file=
+        'https://raw.githubusercontent.com/skypilot-org/mock-train-workflow/refs/heads/main/eval.yaml',
+        envs_override=common_envs,
+    )
+
+    bucket_uuid >> preprocess_task >> train_task >> eval_task
+
+
+sky_train()

--- a/example_skypilot_yamls/nyc_taxi_data.sky.yaml
+++ b/example_skypilot_yamls/nyc_taxi_data.sky.yaml
@@ -4,6 +4,7 @@ resources:
 envs:
   BUCKET_NAME: sky-demo-data-test
   BUCKET_STORE_TYPE: s3
+  DATA_URLS: ''
   YEAR: 2025
 
 file_mounts:
@@ -19,11 +20,10 @@ setup: |
 
   echo "Downloading ${YEAR} data..."
   mkdir ~/data
-  for month in {01..12}; do
-    # Source: https://www.nyc.gov/site/tlc/about/tlc-trip-record-data.page
-    URL=https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_${YEAR}-${month}.parquet
+  IFS=',' read -ra URLS <<< "$DATA_URLS"
+  for URL in "${URLS[@]}"; do
     echo "Downloading $URL..."
-    FILE_PATH=~/data/data_${YEAR}-${month}.parquet
+    FILE_PATH=~/data/$(basename $URL)
     HTTP_CODE=$(curl -L -w "%{http_code}" -o $FILE_PATH $URL)
     if [ "$HTTP_CODE" != "200" ]; then
       echo "Download failed with HTTP code $HTTP_CODE, deleting $FILE_PATH"
@@ -34,4 +34,4 @@ setup: |
 
 run: |
   echo "Processing data..."
-  duckdb -c "COPY (SELECT SUM(total_amount), COUNT(total_amount) FROM read_parquet('~/data/data_${YEAR}-*.parquet')) TO '/bucket/tmp_${YEAR}.txt';"
+  duckdb -c "COPY (SELECT SUM(total_amount), COUNT(total_amount) FROM read_parquet('~/data/*.parquet')) TO '/bucket/tmp_${YEAR}.txt';"

--- a/example_skypilot_yamls/nyc_taxi_data.sky.yaml
+++ b/example_skypilot_yamls/nyc_taxi_data.sky.yaml
@@ -1,0 +1,37 @@
+resources:
+  cpus: 2+
+
+envs:
+  BUCKET_NAME: sky-demo-data-test
+  BUCKET_STORE_TYPE: s3
+  YEAR: 2025
+
+file_mounts:
+  /bucket:
+    name: $BUCKET_NAME
+    store: $BUCKET_STORE_TYPE
+
+setup: |
+  echo "Downloading dependencies..."
+  curl https://install.duckdb.org | sh
+  echo "Testing DuckDB installation..."
+  duckdb -c "SELECT 1;"
+
+  echo "Downloading ${YEAR} data..."
+  mkdir ~/data
+  for month in {01..12}; do
+    # Source: https://www.nyc.gov/site/tlc/about/tlc-trip-record-data.page
+    URL=https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_${YEAR}-${month}.parquet
+    echo "Downloading $URL..."
+    FILE_PATH=~/data/data_${YEAR}-${month}.parquet
+    HTTP_CODE=$(curl -L -w "%{http_code}" -o $FILE_PATH $URL)
+    if [ "$HTTP_CODE" != "200" ]; then
+      echo "Download failed with HTTP code $HTTP_CODE, deleting $FILE_PATH"
+      rm -f $FILE_PATH
+    fi &
+  done
+  wait
+
+run: |
+  echo "Processing data..."
+  duckdb -c "COPY (SELECT SUM(total_amount), COUNT(total_amount) FROM read_parquet('~/data/data_${YEAR}-*.parquet')) TO '/bucket/tmp_${YEAR}.txt';"


### PR DESCRIPTION
This PR adds two examples:
1. The mock training workflow as shown in https://docs.skypilot.co/en/airflow-gcp-service-account-example/examples/orchestrators/airflow.html.
2. A distributed data processing workflow that uses the public [NYC taxi parquet data](https://www.nyc.gov/site/tlc/about/tlc-trip-record-data.page) (Inspired by https://duckdb.org/2024/10/16/driving-csv-performance-benchmarking-duckdb-with-the-nyc-taxi-dataset.html and https://tech.marksblogg.com/benchmarks.html) as input, chunks it by year, spins up a SkyPilot cluster for each year to distribute the work to, loads the data and calculates intermediate results (sum, count) using DuckDB, writes to S3/GCS, and finally reduces the result to the total average cost of trips over all the years.

<img width="1508" height="787" alt="Screenshot 2025-09-02 at 8 40 03 PM" src="https://github.com/user-attachments/assets/1ecb0e8f-3d4b-467a-8700-c11e02eb1e47" />

One UX improvement I added is parameterizing the bucket type (S3 or GCS):
<img width="1624" height="984" alt="Screenshot 2025-08-22 at 5 35 16 PM" src="https://github.com/user-attachments/assets/726687ce-da3c-428b-84f6-aa6342c37ac0" />
<img width="1624" height="984" alt="Screenshot 2025-08-22 at 5 35 38 PM" src="https://github.com/user-attachments/assets/1457d81b-d761-423e-8bd5-5e268ae7cf28" />

I also added a Dockerfile for reference on how to install the provider on top of an existing Airflow image.

