### PR TITLE
Support using git workdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,10 @@ USER root
 RUN apt-get update && apt-get install -y git && apt-get clean
 USER airflow
 # TODO: Install from PyPI once released
-RUN pip install git+https://github.com/skypilot-org/airflow-provider-skypilot.git@v0.1.0
+RUN pip install git+https://github.com/skypilot-org/airflow-provider-skypilot.git@v0.1.1
 # Or if building locally:
 # COPY --chown=airflow:root . /opt/airflow/providers/airflow-provider-skypilot/
+# RUN pip install -e /opt/airflow/providers/airflow-provider-skypilot/
 
 # Copy example DAGs to Airflow's DAGs directory
 COPY --chown=airflow:root example_dags/ /opt/airflow/dags/

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ upon successful installation.
         <img alt="Airflow variables" src="https://i.imgur.com/rr7SfFP.png" width="720">
     </p>
 
-3. Import `SkyPilotClusterOperator`, and use it in your Airflow DAG.
+3. Import `SkyPilotClusterOperator`, and use it in your Airflow DAG
 
     ```python
     from skypilot_provider.operators import SkyPilotClusterOperator
@@ -171,6 +171,9 @@ For more details, refer to [Syncing Code, Git, and Files](https://docs.skypilot.
   - `SKYPILOT_GIT_SSH_KEY_PATH`: For SSH URLs like `git@github.com:org/repo.git`.
   - `SKYPILOT_GIT_TOKEN`: For HTTPS URLs like `https://github.com/org/repo.git`.
 
+    <p align="center">
+        <img alt="Airflow git variables" src="https://i.imgur.com/IVbTU3E.png" width="720">
+    </p>
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ More operators like `SkyJobOperator` are in the roadmap, so stay tuned for that 
 
 ## Installation
 
-You can install this package on top of an existing Airflow deployment via `pip install git+https://github.com/skypilot-org/airflow-provider-skypilot.git@v0.1.0`. For the minimum Airflow version supported, see [Requirements](#requirements) below.
+You can install this package on top of an existing Airflow deployment via `pip install git+https://github.com/skypilot-org/airflow-provider-skypilot.git@v0.1.1`. For the minimum Airflow version supported, see [Requirements](#requirements) below.
 
 You should be able to see `airflow-provider-skypilot` on the Providers page
 upon successful installation.
@@ -65,19 +65,19 @@ upon successful installation.
         preprocess_task = SkyPilotClusterOperator(
             task_id="preprocess",
             yaml_file="https://raw.githubusercontent.com/skypilot-org/mock-train-workflow/refs/heads/main/data_preprocessing.yaml",
-            env_vars=env_vars,
+            envs_override=env_vars,
         )
 
         train_task = SkyPilotClusterOperator(
             task_id="train",
             yaml_file="https://raw.githubusercontent.com/skypilot-org/mock-train-workflow/refs/heads/main/train.yaml",
-            env_vars=env_vars,
+            envs_override=env_vars,
         )
 
         eval_task = SkyPilotClusterOperator(
             task_id="eval",
             yaml_file="https://raw.githubusercontent.com/skypilot-org/mock-train-workflow/refs/heads/main/eval.yaml",
-            env_vars=env_vars,
+            envs_override=env_vars,
         )
 
         # Define the workflow
@@ -93,15 +93,16 @@ We put up some additional examples in [examples_dags/](example_dags/), including
 1. Parallel data processing pipeline: [NYC taxi data processing](example_dags/README.md#example-1-nyc-taxi-data-processing-pipeline)
 2. Data preprocessing -> Training -> Eval pipeline: [Machine learning training](example_dags/README.md#example-2-machine-learning-training-pipeline)
 3. Cloud credentials integration: [AWS credentials integration](example_dags/README.md#example-5-aws-credentials-integration), [GCP credentials integration](example_dags/README.md#example-6-gcp-credentials-integration)
+4. Git workdir integration: [Syncing Git workdir](example_dags/README.md#example-7-git-workdir-integration)
 
 ## Managing SkyPilot Version
 
-All operators supports both stable and nightly versions of SkyPilot.
+All operators support both stable and nightly versions of SkyPilot.
 
-- **Default**: Uses the latest stable release
+- **Default**: Uses the latest nightly version (`skypilot-nightly[all]`). We recommend pinning to a stable version in production.
   ```python
   SkyPilotClusterOperator(
-      task_id="my_task",  # skypilot[all] (latest stable)
+      task_id="my_task",  # defaults to skypilot-nightly[all]
       ...
   )
   ```
@@ -149,6 +150,26 @@ and [GCP](https://airflow.apache.org/docs/apache-airflow-providers-google/stable
         ...
     )
     ```
+
+## Optional: Using Git workdir
+
+The operator supports syncing a Git repository as the task's working directory using `workdir` in the SkyPilot YAML file.
+For more details, refer to [Syncing Code, Git, and Files](https://docs.skypilot.co/en/latest/examples/syncing-code-artifacts.html).
+
+1. In your SkyPilot YAML, set a Git workdir:
+
+    ```yaml
+    workdir:
+      url: git@github.com:org/repo.git   # or https://github.com/org/repo.git
+      ref: main
+    run: |
+      ls -la
+      cat README.md
+    ```
+
+2. Set these Airflow Variables to enable authentication for private repos:
+  - `SKYPILOT_GIT_SSH_KEY_PATH`: For SSH URLs like `git@github.com:org/repo.git`.
+  - `SKYPILOT_GIT_TOKEN`: For HTTPS URLs like `https://github.com/org/repo.git`.
 
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ For more details, refer to [Syncing Code, Git, and Files](https://docs.skypilot.
     ```
 
 2. Set these Airflow Variables to enable authentication for private repos:
-  - `SKYPILOT_GIT_SSH_KEY_PATH`: For SSH URLs like `git@github.com:org/repo.git`.
-  - `SKYPILOT_GIT_TOKEN`: For HTTPS URLs like `https://github.com/org/repo.git`.
+   - `SKYPILOT_GIT_SSH_KEY_PATH`: For SSH URLs like `git@github.com:org/repo.git`.
+   - `SKYPILOT_GIT_TOKEN`: For HTTPS URLs like `https://github.com/org/repo.git`.
 
     <p align="center">
         <img alt="Airflow git variables" src="https://i.imgur.com/IVbTU3E.png" width="720">

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ We put up some additional examples in [examples_dags/](example_dags/), including
 
 All operators support both stable and nightly versions of SkyPilot.
 
-- **Default**: Uses the latest nightly version (`skypilot-nightly[all]`). We recommend pinning to a stable version in production.
+- **Default**: Uses the latest nightly version (`skypilot-nightly[all]`). We recommend pinning to a stable version in production
   ```python
   SkyPilotClusterOperator(
       task_id="my_task",  # defaults to skypilot-nightly[all]
@@ -133,7 +133,7 @@ If you have resources that is not accessible with the cloud credentials on the A
 you can use a different cloud credential to grant the remote clusters created by the operator access to those resources.
 
 1. Create connections in Airflow to store your cloud credentials. Today, we support [AWS](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/connections/aws.html)
-and [GCP](https://airflow.apache.org/docs/apache-airflow-providers-google/stable/connections/gcp.html) connections.
+and [GCP](https://airflow.apache.org/docs/apache-airflow-providers-google/stable/connections/gcp.html) connections
     <p align="center">
         <img alt="Airflow connections" src="https://i.imgur.com/9VbD44X.png" width="720">
     </p>
@@ -168,8 +168,8 @@ For more details, refer to [Syncing Code, Git, and Files](https://docs.skypilot.
     ```
 
 2. Set these Airflow Variables to enable authentication for private repos:
-   - `SKYPILOT_GIT_SSH_KEY_PATH`: For SSH URLs like `git@github.com:org/repo.git`.
-   - `SKYPILOT_GIT_TOKEN`: For HTTPS URLs like `https://github.com/org/repo.git`.
+   - `SKYPILOT_GIT_SSH_KEY_PATH`: For SSH URLs like `git@github.com:org/repo.git`
+   - `SKYPILOT_GIT_TOKEN`: For HTTPS URLs like `https://github.com/org/repo.git`
 
     <p align="center">
         <img alt="Airflow git variables" src="https://i.imgur.com/IVbTU3E.png" width="720">

--- a/README.md
+++ b/README.md
@@ -175,6 +175,24 @@ For more details, refer to [Syncing Code, Git, and Files](https://docs.skypilot.
         <img alt="Airflow git variables" src="https://i.imgur.com/IVbTU3E.png" width="720">
     </p>
 
+3. Ensure that the `SKYPILOT_GIT_SSH_KEY_PATH` points to a valid path on your
+Airflow workers. If you are using [Helm](https://artifacthub.io/packages/helm/apache-airflow/airflow) to install Airflow, you can
+set `workers.extraVolumes` and `workers.extraVolumeMounts` on your Helm values.
+For example:
+
+    ```yaml
+    workers:
+      extraVolumes:
+      - name: git-credentials
+        secret:
+          secretName: airflow-ssh-git-secret
+          defaultMode: 0400
+      extraVolumeMounts:
+      - name: git-credentials
+        mountPath: /opt/airflow/.ssh/
+        readOnly: true
+    ```
+
 ## Requirements
 
 The minimum Apache Airflow version supported by this provider distribution is ``2.10.0``.

--- a/example_dags/README.md
+++ b/example_dags/README.md
@@ -11,6 +11,7 @@ This directory contains several example Airflow DAGs to demonstrate how to use t
   + [Example 4: Local Hello World](#example-4-local-hello-world)
   + [Example 5: AWS Credentials Integration](#example-5-aws-credentials-integration)
   + [Example 6: GCP Credentials Integration](#example-6-gcp-credentials-integration)
+  + [Example 7: Git Workdir integration](#example-7-git-workdir-integration)
 * [Running the Examples](#running-the-examples)
 * [(Optional) Setting up Airflow locally using a custom image](#optional-setting-up-airflow-locally-using-a-custom-image)
 * [Triggering the DAG](#triggering-the-dag)
@@ -58,6 +59,14 @@ This directory contains several example Airflow DAGs to demonstrate how to use t
 [sky_gcp_credentials.py](sky_gcp_credentials.py) includes the definition of the DAG. This example demonstrates how to use Google Cloud Platform credentials stored in Airflow connections with SkyPilot tasks. It involves the following stage:
 
 1. **GCP Integration Task**: Sets up Google Cloud SDK, authenticates using provided credentials, and displays the current GCP identity to verify proper credential configuration
+
+### Example 7: Git Workdir integration
+
+[sky_git_workdir.py](sky_git_workdir.py) includes the definition of the DAG. This example
+demonstrates how to sync contents from a Git repo to a remote cluster so that you can run your code
+on the cluster.
+
+1. **Git Workdir Task**: Runs commands under the cloned Git workdir.
 
 ## Running the Examples
 

--- a/example_dags/sky_git_workdir.py
+++ b/example_dags/sky_git_workdir.py
@@ -1,0 +1,27 @@
+import datetime
+
+from airflow import decorators
+
+from skypilot_provider import operators
+
+default_args = {
+    "owner": "airflow",
+    "retries": 1,
+}
+
+
+@decorators.dag(default_args=default_args,
+                start_date=datetime.datetime(2025, 1, 1),
+                catchup=False,
+                tags=["skypilot"])
+def sky_git_workdir():
+    git_workdir_task = operators.SkyPilotClusterOperator(
+        task_id="git_workdir_task",
+        yaml_file=
+        "https://raw.githubusercontent.com/skypilot-org/airflow-provider-skypilot/refs/heads/workdir-examples/example_skypilot_yamls/git_workdir.sky.yaml",
+    )
+
+    git_workdir_task
+
+
+sky_git_workdir()

--- a/example_skypilot_yamls/git_workdir.sky.yaml
+++ b/example_skypilot_yamls/git_workdir.sky.yaml
@@ -1,5 +1,7 @@
 workdir:
-  url: https://github.com/skypilot-org/skypilot.git
+  # Specify SKYPILOT_GIT_SSH_KEY_PATH or SKYPILOT_GIT_TOKEN in Airflow Variables
+  # to be able to access private repositories
+  url: git@github.com:skypilot-org/skypilot.git # or https://github.com/skypilot-org/skypilot.git
   ref: master
 
 resources:

--- a/example_skypilot_yamls/git_workdir.sky.yaml
+++ b/example_skypilot_yamls/git_workdir.sky.yaml
@@ -1,6 +1,6 @@
 workdir:
   url: https://github.com/skypilot-org/skypilot.git
-  ref: main
+  ref: master
 
 resources:
   cpus: 1+

--- a/example_skypilot_yamls/git_workdir.sky.yaml
+++ b/example_skypilot_yamls/git_workdir.sky.yaml
@@ -1,0 +1,10 @@
+workdir:
+  url: https://github.com/skypilot-org/skypilot.git
+  ref: main
+
+resources:
+  cpus: 1+
+
+run: |
+  ls -la
+  cat README.md | grep 'SkyPilot is a '

--- a/skypilot_provider/operators/cluster.py
+++ b/skypilot_provider/operators/cluster.py
@@ -14,6 +14,13 @@ else:
 from .credentials_utils import (CREDENTIAL_HANDLERS, ClusterCredentials,
                                 CredentialsOverride)
 
+SKYPILOT_ENVIRONMENT_VARIABLES = [
+    # (Airflow variable name, SkyPilot environment variable name, required)
+    ('SKYPILOT_API_SERVER_ENDPOINT', 'SKYPILOT_API_SERVER_ENDPOINT', True),
+    ('SKYPILOT_GIT_SSH_KEY_PATH', 'GIT_SSH_KEY_PATH', False),
+    ('SKYPILOT_GIT_TOKEN', 'GIT_TOKEN', False),
+]
+
 
 class SkyPilotClusterOperator(PythonVirtualenvOperator):
     """
@@ -51,7 +58,7 @@ class SkyPilotClusterOperator(PythonVirtualenvOperator):
             raise ValueError('name must be a non-empty string')
 
         if skypilot_version is None:
-            skypilot_requirement = 'skypilot[all]'
+            skypilot_requirement = 'skypilot-nightly[all]'
         elif 'dev' in skypilot_version:
             skypilot_requirement = f'skypilot-nightly[all]=={skypilot_version}'
         else:
@@ -74,10 +81,16 @@ class SkyPilotClusterOperator(PythonVirtualenvOperator):
         self.skypilot_version = skypilot_version
 
     def execute(self, context):
-        api_server_endpoint = Variable.get('SKYPILOT_API_SERVER_ENDPOINT')
-        if not api_server_endpoint:
-            raise AirflowException(
-                'SKYPILOT_API_SERVER_ENDPOINT Variable is not set')
+        os_environ = {}
+        for airflow_variable_name, skypilot_variable_name, required in (
+                SKYPILOT_ENVIRONMENT_VARIABLES):
+            value = Variable.get(airflow_variable_name, default=None)
+            if value is None:
+                if required:
+                    raise AirflowException(
+                        f'{airflow_variable_name} Variable is not set')
+                continue
+            os_environ[skypilot_variable_name] = value
 
         # Get credentials in the main Airflow environment,
         # as it depends on Airflow providers not
@@ -89,7 +102,7 @@ class SkyPilotClusterOperator(PythonVirtualenvOperator):
             'name': self.name,
             'credentials': credentials,
             'envs_override': self.envs_override,
-            'api_server_endpoint': api_server_endpoint,
+            'os_environ': os_environ,
         }
         return super().execute(context)
 
@@ -122,7 +135,7 @@ def run_sky_task_with_credentials(
     name: Optional[str],
     credentials: ClusterCredentials,
     envs_override: Dict[str, str],
-    api_server_endpoint: str,
+    os_environ: Dict[str, str],
 ):
     import os
     import tempfile
@@ -159,7 +172,8 @@ def run_sky_task_with_credentials(
 
                 task_config['file_mounts'][dst_path] = temp_file.name
 
-            task = sky.Task.from_yaml_config(task_config)
+            task = sky.Task.from_yaml_config(
+                task_config).update_envs_and_secrets_from_workdir()
             cluster_name = (name if name is not None else
                             f'{task_name_hint}-{str(uuid.uuid4())[:4]}')
             print(f'Starting SkyPilot cluster {cluster_name}')
@@ -187,8 +201,7 @@ def run_sky_task_with_credentials(
                 except OSError:
                     pass
 
-    os.environ['SKYPILOT_API_SERVER_ENDPOINT'] = api_server_endpoint
-
+    os.environ.update(os_environ)
     cwd = os.getcwd()
     try:
         if yaml_file.startswith(('http://', 'https://')):

--- a/tests/operators/test_cluster.py
+++ b/tests/operators/test_cluster.py
@@ -68,7 +68,7 @@ class TestSkyPilotClusterOperator:
         assert operator.name == 'my-cluster'
 
     @pytest.mark.parametrize("skypilot_version,expected_requirement", [
-        (None, 'skypilot[all]'),
+        (None, 'skypilot-nightly[all]'),
         ('0.10.0', 'skypilot[all]==0.10.0'),
         ('1.0.0.dev20250808', 'skypilot-nightly[all]==1.0.0.dev20250808'),
     ])
@@ -105,7 +105,13 @@ class TestSkyPilotClusterOperator:
         'skypilot_provider.operators.cluster.PythonVirtualenvOperator.execute')
     def test_execute_success(self, mock_super_execute, mock_variable_get,
                              basic_operator_kwargs, mock_credentials):
-        mock_variable_get.return_value = 'http://test-api-server'
+
+        def mock_get(key, default=None):
+            if key == 'SKYPILOT_API_SERVER_ENDPOINT':
+                return 'http://test-api-server'
+            return default
+
+        mock_variable_get.side_effect = mock_get
 
         operator = SkyPilotClusterOperator(**basic_operator_kwargs)
         with patch.object(operator,
@@ -119,7 +125,9 @@ class TestSkyPilotClusterOperator:
             'name': None,
             'credentials': mock_credentials,
             'envs_override': {},
-            'api_server_endpoint': 'http://test-api-server'
+            'os_environ': {
+                'SKYPILOT_API_SERVER_ENDPOINT': 'http://test-api-server'
+            }
         }
         assert operator.op_kwargs == expected_op_kwargs
 
@@ -190,3 +198,113 @@ class TestSkyPilotClusterOperator:
             }
         }
         assert credentials == expected
+
+    @patch('skypilot_provider.operators.cluster.Variable.get')
+    @patch(
+        'skypilot_provider.operators.cluster.PythonVirtualenvOperator.execute')
+    def test_execute_with_git_ssh_key_path(self, mock_super_execute,
+                                           mock_variable_get,
+                                           basic_operator_kwargs,
+                                           mock_credentials):
+
+        def mock_get(key, default=None):
+            if key == 'SKYPILOT_API_SERVER_ENDPOINT':
+                return 'http://test-api-server'
+            elif key == 'SKYPILOT_GIT_SSH_KEY_PATH':
+                return '/path/to/ssh/key'
+            return default
+
+        mock_variable_get.side_effect = mock_get
+
+        operator = SkyPilotClusterOperator(**basic_operator_kwargs)
+        with patch.object(operator,
+                          '_get_credentials',
+                          return_value=mock_credentials):
+            operator.execute({})
+        mock_super_execute.assert_called_once()
+
+        expected_op_kwargs = {
+            'yaml_file': '/test/path/test.sky.yaml',
+            'name': None,
+            'credentials': mock_credentials,
+            'envs_override': {},
+            'os_environ': {
+                'SKYPILOT_API_SERVER_ENDPOINT': 'http://test-api-server',
+                'GIT_SSH_KEY_PATH': '/path/to/ssh/key'
+            }
+        }
+        assert operator.op_kwargs == expected_op_kwargs
+
+    @patch('skypilot_provider.operators.cluster.Variable.get')
+    @patch(
+        'skypilot_provider.operators.cluster.PythonVirtualenvOperator.execute')
+    def test_execute_with_git_token(self, mock_super_execute,
+                                    mock_variable_get, basic_operator_kwargs,
+                                    mock_credentials):
+
+        def mock_get(key, default=None):
+            if key == 'SKYPILOT_API_SERVER_ENDPOINT':
+                return 'http://test-api-server'
+            elif key == 'SKYPILOT_GIT_TOKEN':
+                return 'github_token_123'
+            return default
+
+        mock_variable_get.side_effect = mock_get
+
+        operator = SkyPilotClusterOperator(**basic_operator_kwargs)
+        with patch.object(operator,
+                          '_get_credentials',
+                          return_value=mock_credentials):
+            operator.execute({})
+        mock_super_execute.assert_called_once()
+
+        expected_op_kwargs = {
+            'yaml_file': '/test/path/test.sky.yaml',
+            'name': None,
+            'credentials': mock_credentials,
+            'envs_override': {},
+            'os_environ': {
+                'SKYPILOT_API_SERVER_ENDPOINT': 'http://test-api-server',
+                'GIT_TOKEN': 'github_token_123'
+            }
+        }
+        assert operator.op_kwargs == expected_op_kwargs
+
+    @patch('skypilot_provider.operators.cluster.Variable.get')
+    @patch(
+        'skypilot_provider.operators.cluster.PythonVirtualenvOperator.execute')
+    def test_execute_with_all_git_env_vars(self, mock_super_execute,
+                                           mock_variable_get,
+                                           basic_operator_kwargs,
+                                           mock_credentials):
+
+        def mock_get(key, default=None):
+            if key == 'SKYPILOT_API_SERVER_ENDPOINT':
+                return 'http://test-api-server'
+            elif key == 'SKYPILOT_GIT_SSH_KEY_PATH':
+                return '/path/to/ssh/key'
+            elif key == 'SKYPILOT_GIT_TOKEN':
+                return 'github_token_123'
+            return default
+
+        mock_variable_get.side_effect = mock_get
+
+        operator = SkyPilotClusterOperator(**basic_operator_kwargs)
+        with patch.object(operator,
+                          '_get_credentials',
+                          return_value=mock_credentials):
+            operator.execute({})
+        mock_super_execute.assert_called_once()
+
+        expected_op_kwargs = {
+            'yaml_file': '/test/path/test.sky.yaml',
+            'name': None,
+            'credentials': mock_credentials,
+            'envs_override': {},
+            'os_environ': {
+                'SKYPILOT_API_SERVER_ENDPOINT': 'http://test-api-server',
+                'GIT_SSH_KEY_PATH': '/path/to/ssh/key',
+                'GIT_TOKEN': 'github_token_123'
+            }
+        }
+        assert operator.op_kwargs == expected_op_kwargs


### PR DESCRIPTION
This PR adds support for using SkyPilot YAMLs with git `workdir`, as shown in https://docs.skypilot.co/en/latest/examples/syncing-code-artifacts.html.

Note that due to internal implementation details, using git `workdir` from the SDK is only possible after this [PR](https://github.com/skypilot-org/skypilot/pull/7137), which didn't make it to today's nightly, so it will only be available in `>=1.0.0.dev20250912`, or stable version `>0.10.3`.

Because of that, I'm proposing changing the default value of `skypilot_version` (the SDK version we use) from `skypilot[all]` (latest stable) to `skypilot-nightly[all]`. Because otherwise, users will have to explicitly set a version for a few weeks until we release our next version after `0.10.3`.

README preview: https://github.com/skypilot-org/airflow-provider-skypilot/tree/workdir-examples

Tested:
- [x] Public repo using SSH URL
- [x] Public repo using HTTPS URL
- [x] Private repo using SSH URL (`SKYPILOT_GIT_SSH_KEY_PATH`)
- [x] Private repo using HTTPS URL (`SKYPILOT_GIT_TOKEN`) -> ~~Blocked by https://github.com/skypilot-org/skypilot/pull/7146~~